### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 
 	"require-dev": {
-		"typo3-console/composer-typo3-auto-install": "dev-master",
+		"typo3-console/composer-typo3-auto-install": "^0.3",
 		"nimut/testing-framework": "^4.1",
 		"phpunit/phpunit": "*",
 		"typo3/cms-adminpanel": "^9.5",


### PR DESCRIPTION
composer-typo3-auto-install requires typo3-console > 6.0, which is not compatible with TYPO3 9.5.